### PR TITLE
Use macros for string interpolation for better error messages

### DIFF
--- a/api/shared/src/main/scala-2.12/play/twirl/api/Compat.scala
+++ b/api/shared/src/main/scala-2.12/play/twirl/api/Compat.scala
@@ -21,7 +21,7 @@ private[api] trait Compat {
 }
 
 private[api] trait FormatValueInstancesCompat {
-  final implicit def traversableOnceFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def traversableOnceFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, TraversableOnce[V]] =
     FormatValue.instance((format: F, v: TraversableOnce[V]) =>
@@ -31,15 +31,14 @@ private[api] trait FormatValueInstancesCompat {
       }
     )
 
-  final implicit def traversableOnceNothingFormatValue[T <: Appendable[T], F <: Format[T]]
-      : FormatValue[T, F, TraversableOnce[Nothing]] =
+  final implicit def traversableOnceNothingFormatValue[T, F <: Format[T]]: FormatValue[T, F, TraversableOnce[Nothing]] =
     FormatValue.instance((format: F, _: TraversableOnce[Nothing]) => format.empty)
 
-  final implicit def optionFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def optionFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, Option[V]] =
     FormatValue.instance((format: F, o: Option[V]) => o.fold(format.empty)(vFormatValue(format, _)))
 
-  final implicit def noneFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, None.type] =
+  final implicit def noneFormatValue[T, F <: Format[T]]: FormatValue[T, F, None.type] =
     FormatValue.instance((format: F, _: None.type) => format.empty)
 }

--- a/api/shared/src/main/scala-2.13/play/twirl/api/Compat.scala
+++ b/api/shared/src/main/scala-2.13/play/twirl/api/Compat.scala
@@ -15,7 +15,7 @@ private[api] trait Compat {
 }
 
 private[api] trait FormatValueInstancesCompat {
-  final implicit def iterableOnceFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def iterableOnceFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, IterableOnce[V]] =
     FormatValue.instance((format: F, iterable: IterableOnce[V]) =>
@@ -27,7 +27,6 @@ private[api] trait FormatValueInstancesCompat {
       }
     )
 
-  final implicit def iterableOnceNothingFormatValue[T <: Appendable[T], F <: Format[T]]
-      : FormatValue[T, F, IterableOnce[Nothing]] =
+  final implicit def iterableOnceNothingFormatValue[T, F <: Format[T]]: FormatValue[T, F, IterableOnce[Nothing]] =
     FormatValue.instance((format: F, _: IterableOnce[Nothing]) => format.empty)
 }

--- a/api/shared/src/main/scala-2/play/twirl/api/StringInterpolationCompat.scala
+++ b/api/shared/src/main/scala-2/play/twirl/api/StringInterpolationCompat.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) from 2025 BondLink, 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.twirl.api
+
+import scala.language.experimental.macros
+import scala.language.implicitConversions
+
+/**
+ * Brings the template engine as a
+ * [[http://docs.scala-lang.org/overviews/core/string-interpolation.html string interpolator]].
+ *
+ * Basic usage:
+ *
+ * {{{
+ *   import play.twirl.api.StringInterpolation
+ *
+ *   val name = "Martin"
+ *   val htmlFragment: Html = html"&lt;div&gt;Hello \$name&lt;/div&gt;"
+ * }}}
+ *
+ * Three interpolators are available: `html`, `xml` and `js`.
+ */
+final class StringInterpolationOps(private val sc: StringContext) extends AnyVal {
+  final def html(args: Any*): Html = macro StringInterpolationMacros.htmlImpl
+  final def xml(args: Any*): Xml = macro StringInterpolationMacros.xmlImpl
+  final def js(args: Any*): JavaScript = macro StringInterpolationMacros.jsImpl
+}
+
+private[api] trait StringInterpolationCompat {
+  @inline final implicit def toStringInterpolationOps(sc: StringContext): StringInterpolationOps =
+    new StringInterpolationOps(sc)
+}

--- a/api/shared/src/main/scala-2/play/twirl/api/StringInterpolationMacros.scala
+++ b/api/shared/src/main/scala-2/play/twirl/api/StringInterpolationMacros.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) from 2025 BondLink, 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.twirl.api
+
+import scala.reflect.macros.blackbox.Context
+
+final class StringInterpolationMacros(val c: Context) {
+  import c.universe._
+
+  private lazy val staticStringExprs = c.prefix.tree match {
+    case Apply(_, List(Apply(_, strs))) => strs
+    case _                              => c.abort(c.enclosingPosition, "Unexpected string interpolation invocation")
+  }
+
+  private def interpolateImpl[T, F <: Format[T]](format: c.Expr[F], argExprs: Seq[c.Expr[Any]])(implicit
+      tTypeTag: c.WeakTypeTag[T],
+      fTypeTag: c.WeakTypeTag[F]
+  ): c.Expr[T] = {
+    val tType      = tTypeTag.tpe
+    val fType      = fTypeTag.tpe
+    val arr        = Array.ofDim[c.Expr[T]](argExprs.size + staticStringExprs.size)
+    val staticStrs = staticStringExprs.iterator
+    val args       = argExprs.iterator
+    arr(0) = c.Expr[T](q"$format.raw(${staticStrs.next()})")
+    var i = 1
+    while (staticStrs.hasNext) {
+      val arg = args.next()
+      arr(i) = c.Expr[T](
+        q"_root_.scala.Predef.implicitly[_root_.play.twirl.api.FormatValue[$tType, $fType, ${arg.tree.tpe}]].apply($format, $arg)"
+      )
+      arr(i + 1) = c.Expr[T](q"$format.raw(${staticStrs.next()})")
+      i += 2
+    }
+    c.Expr(q"$format.fill(_root_.scala.collection.immutable.Seq(..${arr.toIndexedSeq}))")
+  }
+
+  final def htmlImpl(args: c.Expr[Any]*): c.Expr[Html] =
+    interpolateImpl[Html, HtmlFormat.type](c.Expr[HtmlFormat.type](q"_root_.play.twirl.api.HtmlFormat"), args)
+
+  final def xmlImpl(args: c.Expr[Any]*): c.Expr[Xml] =
+    interpolateImpl[Xml, XmlFormat.type](c.Expr[XmlFormat.type](q"_root_.play.twirl.api.XmlFormat"), args)
+
+  final def jsImpl(args: c.Expr[Any]*): c.Expr[JavaScript] =
+    interpolateImpl[JavaScript, JavaScriptFormat.type](
+      c.Expr[JavaScriptFormat.type](q"_root_.play.twirl.api.JavaScriptFormat"),
+      args
+    )
+}

--- a/api/shared/src/main/scala-3/play/twirl/api/Compat.scala
+++ b/api/shared/src/main/scala-3/play/twirl/api/Compat.scala
@@ -15,7 +15,7 @@ private[api] trait Compat {
 }
 
 private[api] trait FormatValueInstancesCompat {
-  final implicit def iterableOnceFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def iterableOnceFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, IterableOnce[V]] =
     FormatValue.instance((format: F, iterable: IterableOnce[V]) =>
@@ -27,7 +27,6 @@ private[api] trait FormatValueInstancesCompat {
       }
     )
 
-  final implicit def iterableOnceNothingFormatValue[T <: Appendable[T], F <: Format[T]]
-      : FormatValue[T, F, IterableOnce[Nothing]] =
+  final implicit def iterableOnceNothingFormatValue[T, F <: Format[T]]: FormatValue[T, F, IterableOnce[Nothing]] =
     FormatValue.instance((format: F, _: IterableOnce[Nothing]) => format.empty)
 }

--- a/api/shared/src/main/scala-3/play/twirl/api/StringInterpolationCompat.scala
+++ b/api/shared/src/main/scala-3/play/twirl/api/StringInterpolationCompat.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) from 2025 BondLink, 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.twirl.api
+
+private[api] trait StringInterpolationCompat { self =>
+
+  /**
+   * This and `given StringInterpolation below` are a hack to let both of these styles of imports work as they do in
+   * Scala 2:
+   *
+   * {{{
+   * import play.twirl.api.*
+   * import play.twirl.api.StringInterpolation
+   * }}}
+   */
+  extension (inline sc: StringContext) {
+    inline final def html(inline args: Any*): Html     = ${ StringInterpolationMacros.htmlImpl('sc, 'args) }
+    inline final def xml(inline args: Any*): Xml       = ${ StringInterpolationMacros.xmlImpl('sc, 'args) }
+    inline final def js(inline args: Any*): JavaScript = ${ StringInterpolationMacros.jsImpl('sc, 'args) }
+  }
+
+  /**
+   * Brings the template engine as a
+   * [[http://docs.scala-lang.org/overviews/core/string-interpolation.html string interpolator]].
+   *
+   * Basic usage:
+   *
+   * {{{
+   *   import play.twirl.api.StringInterpolation
+   *
+   *   val name = "Martin"
+   *   val htmlFragment: Html = html"&lt;div&gt;Hello \$name&lt;/div&gt;"
+   * }}}
+   *
+   * Three interpolators are available: `html`, `xml` and `js`.
+   */
+  given StringInterpolation: {} with {
+    export self.html
+    export self.xml
+    export self.js
+  }
+}

--- a/api/shared/src/main/scala-3/play/twirl/api/StringInterpolationMacros.scala
+++ b/api/shared/src/main/scala-3/play/twirl/api/StringInterpolationMacros.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) from 2025 BondLink, 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.twirl.api
+
+import scala.compiletime.summonInline
+import scala.quoted.*
+
+private[api] object StringInterpolationMacros {
+  private def interpolateImpl[T: Type, F <: Format[T]: Type](
+      formatExpr: Expr[F],
+      scExpr: Expr[StringContext],
+      argsExpr: Expr[Seq[Any]],
+  )(using q: Quotes): Expr[T] = {
+    import q.reflect.*
+
+    val staticStrs0: Seq[String]                              = scExpr.valueOrAbort.parts
+    val (staticStrs, staticStrsSize): (Iterator[String], Int) = (staticStrs0.iterator, staticStrs0.size)
+    val (args, argsSize): (Iterator[Expr[Any]], Int) = argsExpr match {
+      case Varargs(s) => (s.iterator, s.size)
+      case _          => report.errorAndAbort("Unexpected string interpolation invocation")
+    }
+
+    var i               = 1
+    val arr             = Array.ofDim[Expr[T]](staticStrsSize + argsSize)
+    val formatStaticStr = () => '{ $formatExpr.raw(${ Expr(staticStrs.next) }) }
+
+    arr(0) = formatStaticStr()
+
+    while staticStrs.hasNext do {
+      val formattedArg = args.next match { case '{ $x: x } => '{ summonInline[FormatValue[T, F, x]]($formatExpr, $x) } }
+      val formattedStaticStr = formatStaticStr()
+
+      arr(i) = formattedArg
+      arr(i + 1) = formattedStaticStr
+      i += 2
+    }
+
+    '{ $formatExpr.fill(${ Expr.ofSeq(arr.toSeq) }) }
+  }
+
+  def htmlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using q: Quotes): Expr[Html] =
+    interpolateImpl('{ HtmlFormat }, scExpr, argsExpr)
+
+  def xmlImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using q: Quotes): Expr[Xml] =
+    interpolateImpl('{ XmlFormat }, scExpr, argsExpr)
+
+  def jsImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(using q: Quotes): Expr[JavaScript] =
+    interpolateImpl('{ JavaScriptFormat }, scExpr, argsExpr)
+}

--- a/api/shared/src/main/scala/play/twirl/api/Format.scala
+++ b/api/shared/src/main/scala/play/twirl/api/Format.scala
@@ -19,7 +19,7 @@ trait Appendable[T]
  * @tparam T
  *   The underlying type that this format applies to.
  */
-trait Format[T <: Appendable[T]] {
+trait Format[T] {
   type Appendable = T
 
   /**

--- a/api/shared/src/main/scala/play/twirl/api/FormatValue.scala
+++ b/api/shared/src/main/scala/play/twirl/api/FormatValue.scala
@@ -6,9 +6,8 @@ package play.twirl.api
 
 import java.util.{ List => JList }
 import java.util.Optional
-import scala.language.implicitConversions
 
-sealed trait FormatValue[T <: Appendable[T], F <: Format[T], -V] { self =>
+sealed trait FormatValue[T, F <: Format[T], -V] { self =>
   def apply(format: F, value: V): T
 
   final def contramap[B](f: B => V): FormatValue[T, F, B] =
@@ -16,17 +15,17 @@ sealed trait FormatValue[T <: Appendable[T], F <: Format[T], -V] { self =>
 }
 
 object FormatValue extends FormatValueInstances0 {
-  class Companion[T <: Appendable[T], F <: Format[T]] {
+  class Companion[T, F <: Format[T]] {
     @inline final def apply[V](implicit f: FormatValue[T, F, V]): FormatValue[T, F, V] = f
 
     final def instance[V](f: (F, V) => T): FormatValue[T, F, V] = FormatValue.instance(f)
   }
 
-  @inline final def apply[T <: Appendable[T], F <: Format[T], V](implicit
+  @inline final def apply[T, F <: Format[T], V](implicit
       f: FormatValue[T, F, V]
   ): FormatValue[T, F, V] = f
 
-  def instance[T <: Appendable[T], F <: Format[T], V](f: (F, V) => T): FormatValue[T, F, V] =
+  def instance[T, F <: Format[T], V](f: (F, V) => T): FormatValue[T, F, V] =
     new FormatValue[T, F, V] {
       def apply(format: F, value: V): T =
         value match {
@@ -34,106 +33,93 @@ object FormatValue extends FormatValueInstances0 {
           case _    => f(format, value)
         }
     }
-
-  final case class Formatted[T <: Appendable[T], F <: Format[T]](formatted: T) extends AnyVal
-  object Formatted {
-    implicit def mat[T <: Appendable[T], F <: Format[T], V](value: V)(implicit
-        formatValue: FormatValue[T, F, V],
-        format: ValueOf[F]
-    ): Formatted[T, F] =
-      Formatted(formatValue(format.value, value))
-
-    implicit def formatValueFormatted[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Formatted[T, F]] =
-      FormatValue.instance((_: F, v: Formatted[T, F]) => v.formatted)
-  }
 }
 
 sealed trait FormatValueInstances0 extends FormatValueInstances1 {
-  final implicit def tFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, T] =
+  final implicit def tFormatValue[T, F <: Format[T]]: FormatValue[T, F, T] =
     FormatValue.instance((_: F, t: T) => t)
 
-  final implicit def unitFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Unit] =
+  final implicit def unitFormatValue[T, F <: Format[T]]: FormatValue[T, F, Unit] =
     FormatValue.instance((format: F, _: Unit) => format.empty)
 
-  final implicit def byteFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Byte] =
+  final implicit def byteFormatValue[T, F <: Format[T]]: FormatValue[T, F, Byte] =
     FormatValue.instance((format: F, byte: Byte) => format.escape(byte.toString))
 
-  final implicit def javaByteFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Byte] =
+  final implicit def javaByteFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Byte] =
     FormatValue.instance((format: F, byte: java.lang.Byte) => format.escape(byte.toString))
 
-  final implicit def booleanFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Boolean] =
+  final implicit def booleanFormatValue[T, F <: Format[T]]: FormatValue[T, F, Boolean] =
     FormatValue.instance((format: F, bool: Boolean) => format.escape(bool.toString))
 
-  final implicit def javaBooleanFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Boolean] =
+  final implicit def javaBooleanFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Boolean] =
     FormatValue.instance((format: F, bool: java.lang.Boolean) => format.escape(bool.toString))
 
-  final implicit def charFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Char] =
+  final implicit def charFormatValue[T, F <: Format[T]]: FormatValue[T, F, Char] =
     FormatValue.instance((format: F, char: Char) => format.escape(char.toString))
 
-  final implicit def javaCharacterFormatValue[T <: Appendable[T], F <: Format[T]]
-      : FormatValue[T, F, java.lang.Character] =
+  final implicit def javaCharacterFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Character] =
     FormatValue.instance((format: F, char: java.lang.Character) => format.escape(char.toString))
 
-  final implicit def doubleFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Double] =
+  final implicit def doubleFormatValue[T, F <: Format[T]]: FormatValue[T, F, Double] =
     FormatValue.instance((format: F, dbl: Double) => format.escape(dbl.toString))
 
-  final implicit def javaDoubleFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Double] =
+  final implicit def javaDoubleFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Double] =
     FormatValue.instance((format: F, dbl: java.lang.Double) => format.escape(dbl.toString))
 
-  final implicit def floatFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Float] =
+  final implicit def floatFormatValue[T, F <: Format[T]]: FormatValue[T, F, Float] =
     FormatValue.instance((format: F, float: Float) => format.escape(float.toString))
 
-  final implicit def javaFloatFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Float] =
+  final implicit def javaFloatFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Float] =
     FormatValue.instance((format: F, float: java.lang.Float) => format.escape(float.toString))
 
-  final implicit def intFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Int] =
+  final implicit def intFormatValue[T, F <: Format[T]]: FormatValue[T, F, Int] =
     FormatValue.instance((format: F, int: Int) => format.escape(int.toString))
 
-  final implicit def javaIntegerFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Integer] =
+  final implicit def javaIntegerFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Integer] =
     FormatValue.instance((format: F, int: java.lang.Integer) => format.escape(int.toString))
 
-  final implicit def longFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Long] =
+  final implicit def longFormatValue[T, F <: Format[T]]: FormatValue[T, F, Long] =
     FormatValue.instance((format: F, long: Long) => format.escape(long.toString))
 
-  final implicit def javaLongFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Long] =
+  final implicit def javaLongFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Long] =
     FormatValue.instance((format: F, long: java.lang.Long) => format.escape(long.toString))
 
-  final implicit def shortFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, Short] =
+  final implicit def shortFormatValue[T, F <: Format[T]]: FormatValue[T, F, Short] =
     FormatValue.instance((format: F, short: Short) => format.escape(short.toString))
 
-  final implicit def javaShortFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.lang.Short] =
+  final implicit def javaShortFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.lang.Short] =
     FormatValue.instance((format: F, short: java.lang.Short) => format.escape(short.toString))
 
-  final implicit def stringFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, String] =
+  final implicit def stringFormatValue[T, F <: Format[T]]: FormatValue[T, F, String] =
     FormatValue.instance((format: F, string: String) => format.escape(string))
 
-  final implicit def javaFileFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.io.File] =
+  final implicit def javaFileFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.io.File] =
     FormatValue.instance((format: F, file: java.io.File) => format.escape(file.toString))
 
-  final implicit def javaURLFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.net.URL] =
+  final implicit def javaURLFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.net.URL] =
     FormatValue.instance((format: F, url: java.net.URL) => format.escape(url.toString))
 
-  final implicit def javaUUIDFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, java.util.UUID] =
+  final implicit def javaUUIDFormatValue[T, F <: Format[T]]: FormatValue[T, F, java.util.UUID] =
     FormatValue.instance((format: F, uuid: java.util.UUID) => format.escape(uuid.toString))
 
-  final implicit def xmlNodeSeqFormatValue[T <: Appendable[T], F <: Format[T]]: FormatValue[T, F, scala.xml.NodeSeq] =
+  final implicit def xmlNodeSeqFormatValue[T, F <: Format[T]]: FormatValue[T, F, scala.xml.NodeSeq] =
     FormatValue.instance((format: F, xml: scala.xml.NodeSeq) => format.raw(xml.toString))
 }
 
 sealed trait FormatValueInstances1 extends FormatValueInstancesCompat {
-  final implicit def arrayFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def arrayFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, Array[V]] =
     FormatValue.instance((format: F, arr: Array[V]) => format.fill(arr.view.map(vFormatValue(format, _)).toList))
 
-  final implicit def javaListFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def javaListFormatValue[T, F <: Format[T], V](implicit
       vFormatValue: FormatValue[T, F, V]
   ): FormatValue[T, F, JList[V]] =
     FormatValue.instance((format: F, list: JList[V]) =>
       format.fill(javaListToScala(list).map(vFormatValue(format, _)).toList)
     )
 
-  final implicit def optionalFormatValue[T <: Appendable[T], F <: Format[T], V](implicit
+  final implicit def optionalFormatValue[T, F <: Format[T], V](implicit
       optionVFormatValue: FormatValue[T, F, Option[V]]
   ): FormatValue[T, F, Optional[V]] =
     FormatValue.instance((format: F, option: Optional[V]) =>

--- a/api/shared/src/main/scala/play/twirl/api/package.scala
+++ b/api/shared/src/main/scala/play/twirl/api/package.scala
@@ -4,9 +4,7 @@
 
 package play.twirl
 
-import scala.reflect.ClassTag
-
-package object api extends Compat {
+package object api extends Compat with StringInterpolationCompat {
   type FormatHtml[-V] = FormatValue[Html, HtmlFormat.type, V]
   object FormatHtml extends FormatValue.Companion[Html, HtmlFormat.type]
 
@@ -18,46 +16,4 @@ package object api extends Compat {
 
   type FormatJavaScript[-V] = FormatValue[JavaScript, JavaScriptFormat.type, V]
   object FormatJavaScript extends FormatValue.Companion[JavaScript, JavaScriptFormat.type]
-
-  /**
-   * Brings the template engine as a
-   * [[http://docs.scala-lang.org/overviews/core/string-interpolation.html string interpolator]].
-   *
-   * Basic usage:
-   *
-   * {{{
-   *   import play.twirl.api.StringInterpolation
-   *
-   *   val name = "Martin"
-   *   val htmlFragment: Html = html"&lt;div&gt;Hello \$name&lt;/div&gt;"
-   * }}}
-   *
-   * Three interpolators are available: `html`, `xml` and `js`.
-   */
-  implicit class StringInterpolation(val sc: StringContext) extends AnyVal {
-    def html(args: FormatValue.Formatted[Html, HtmlFormat.type]*): Html = interpolate(args, HtmlFormat)
-
-    def xml(args: FormatValue.Formatted[Xml, XmlFormat.type]*): Xml = interpolate(args, XmlFormat)
-
-    def js(args: FormatValue.Formatted[JavaScript, JavaScriptFormat.type]*): JavaScript =
-      interpolate(args, JavaScriptFormat)
-
-    def interpolate[T <: Appendable[T]: ClassTag, F <: Format[T]](
-        args: Seq[FormatValue.Formatted[T, F]],
-        format: F
-    ): T = {
-      checkStringContextLengths(sc, args)
-      val array       = Array.ofDim[T](args.size + sc.parts.size)
-      val strings     = sc.parts.iterator
-      val expressions = args.iterator
-      array(0) = format.raw(strings.next())
-      var i = 1
-      while (strings.hasNext) {
-        array(i) = expressions.next().formatted
-        array(i + 1) = format.raw(strings.next())
-        i += 2
-      }
-      format.fill(array.toIndexedSeq)
-    }
-  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ lazy val nodeJs = {
     new NodeJSEnv()
 }
 
+def scalaReflect(scalaV: String) = "org.scala-lang" % "scala-reflect" % scalaV % "provided"
+
 lazy val api = crossProject(JVMPlatform, JSPlatform)
   .in(file("api"))
   .enablePlugins(Common)
@@ -55,13 +57,14 @@ lazy val api = crossProject(JVMPlatform, JSPlatform)
         "org.scalatest.tools.ScalaTestFramework"
       )
     ),
-    libraryDependencies += "org.scala-lang.modules" %%% "scala-xml" % "2.3.0",
-    libraryDependencies += "org.scalatest"          %%% "scalatest" % ScalaTestVersion % Test,
-    libraryDependencies ++= (if (scalaVersion.value == Scala212)
-                               Seq(
-                                 "com.chuusai" %%% "shapeless" % "2.3.7"
-                               )
-                             else Seq())
+    libraryDependencies ++= Seq(
+      "org.scala-lang.modules" %%% "scala-xml" % "2.3.0",
+      "org.scalatest"          %%% "scalatest" % ScalaTestVersion % Test,
+    ) ++ (scalaVersion.value match {
+      case v @ Scala212 => Seq(scalaReflect(v), "com.chuusai" %%% "shapeless" % "2.3.13")
+      case v @ Scala213 => Seq(scalaReflect(v))
+      case Scala33      => Seq()
+    })
   )
 
 lazy val apiJvm = api.jvm

--- a/sbt-twirl/src/sbt-test/twirl/compile-scala3/src/test/scala/test/Test.scala
+++ b/sbt-twirl/src/sbt-test/twirl/compile-scala3/src/test/scala/test/Test.scala
@@ -1,6 +1,6 @@
 package test
 
-import play.twirl.api.*
+import play.twirl.api.HtmlFormat
 
 object Test extends App {
   def test(template: HtmlFormat.Appendable, expected: String) = {


### PR DESCRIPTION
With these changes string interpolation now gives an implicit/given error when an instance of `FormatValue` is not found for an interpolated value as opposed to a type mismatch error.

### Before

```scala
import play.twirl.api.*
case class Foo()
html"a ${Foo()} b"
```

yields

```scala
-- [E007] Type Mismatch Error: -------------------------------------------------
1 |html"a ${Foo()} b"
  |         ^^^^^
  |       Found:    Foo
  |       Required: play.twirl.api.FormatValue.Formatted[play.twirl.api.Html,
  |         play.twirl.api.HtmlFormat.type]
  |
  | longer explanation available when compiling with `-explain`
```

### After

```scala
import play.twirl.api.*
case class Foo()
html"a ${Foo()} b"
```

yields

```scala
-- [E172] Type Error: ----------------------------------------------------------
 1 |html"a ${Foo()} b"
   |^^^^^^^^^^^^^^^^^^
   |No given instance of type play.twirl.api.FormatValue[play.twirl.api.Html, play.twirl.api.HtmlFormat.type,
   |  Foo] was found.
   |I found:
   |
   |    play.twirl.api.FormatValue.tFormatValue[T, F]
   |
   |But method tFormatValue in trait FormatValueInstances0 does not match type play.twirl.api.FormatValue[play.twirl.api.Html, play.twirl.api.HtmlFormat.type,
   |  Foo].
   |----------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from StringInterpolationMacros.scala:32
32 |      val formattedArg = args.next match { case '{ $x: x } => '{ summonInline[FormatValue[T, F, x]]($formatExpr, $x) } }
   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from StringInterpolationMacros.scala:32
32 |      val formattedArg = args.next match { case '{ $x: x } => '{ summonInline[FormatValue[T, F, x]]($formatExpr, $x) } }
   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ----------------------------------------------------------------------------
```